### PR TITLE
Fix for "Type inference" error after Flutter/Kotlin update

### DIFF
--- a/android/src/main/kotlin/com/example/flutterlaunch/FlutterLaunchPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutterlaunch/FlutterLaunchPlugin.kt
@@ -30,8 +30,8 @@ class FlutterLaunchPlugin(val mRegistrar: Registrar): MethodCallHandler {
 
             if (call.method.equals("launchWathsApp")) {
 
-                val phone: String = call.argument("phone")
-                val message: String = call.argument("message")
+                val phone: String? = call.argument("phone")
+                val message: String? = call.argument("message")
 
                 val url: String = "https://api.whatsapp.com/send?phone=$phone&text=${URLEncoder.encode(message, "UTF-8")}"
 
@@ -47,7 +47,7 @@ class FlutterLaunchPlugin(val mRegistrar: Registrar): MethodCallHandler {
             }
 
             if (call.method.equals("hasApp")) {
-                val app: String = call.argument("name");
+                val app: String? = call.argument("name");
 
                 when(app) {
                     "facebook" -> result.success(appInstalledOrNot("com.facebook.katana"))


### PR DESCRIPTION
Fix for "Type inference" issue after update to newest Kotlin/Flutter.

flutter_launch-0.1.2/android/src/main/kotlin/com/example/flutterlaunch/FlutterLaunchPlugin.kt: (33, 42): Type inference failed. Expected type mismatch: inferred type is String? but String was expected
flutter_launch-0.1.2/android/src/main/kotlin/com/example/flutterlaunch/FlutterLaunchPlugin.kt: (34, 44): Type inference failed. Expected type mismatch: inferred type is String? but String was expected
flutter_launch-0.1.2/android/src/main/kotlin/com/example/flutterlaunch/FlutterLaunchPlugin.kt: (50, 40): Type inference failed. Expected type mismatch: inferred type is String? but String was expected

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_launch:compileDebugKotlin'.